### PR TITLE
upgrade: Kyo to 0.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.4.2]
+        scala: [3.5.1]
         java: [temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.4.2]
+        scala: [3.5.1]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -95,12 +95,12 @@ jobs:
           java-version: 21
           cache: sbt
 
-      - name: Download target directories (3.4.2)
+      - name: Download target directories (3.5.1)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-3.4.2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.5.1-${{ matrix.java }}
 
-      - name: Inflate target directories (3.4.2)
+      - name: Inflate target directories (3.5.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import io.kaizensolutions.virgil.codecs.*
 import io.kaizensolutions.virgil.cql.*
 import kyo.*
 
-val program: Unit < (Envs[CQLExecutor] & Fibers) =
+val program: Unit < (Env[CQLExecutor] & Async) =
   val one = 1
   val two = 2
   val Alice = "Alice"
@@ -35,6 +35,6 @@ val program: Unit < (Envs[CQLExecutor] & Fibers) =
   for
     _                 <- CQLExecutor.executeMutation(insertAlice)
     _                 <- CQLExecutor.executeMutation(insertBob)
-    (aliceAndBob, _)  <- CQLExecutor.execute(query).runSeq
+    (aliceAndBob, _)  <- CQLExecutor.execute(query).run
   yield ()
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 inThisBuild {
-  val scala3 = "3.4.2"
+  val scala3 = "3.5.1"
 
   List(
     scalaVersion       := scala3,
@@ -11,6 +11,8 @@ inThisBuild {
       "-unchecked",
       "-deprecation",
       "-Wvalue-discard",
+      "-Wnonunit-statement",
+      "-Wconf:msg=(discarded.*value|pure.*statement):error",
       "-Wunused:all",
       "-language:implicitConversions"
     ),
@@ -66,7 +68,7 @@ lazy val root =
     .settings(
       name := "virgil-kyo",
       libraryDependencies ++= Seq(
-        "io.getkyo"           %% "kyo-core"    % "0.10.1",
+        "io.getkyo"           %% "kyo-core"    % "0.14.1",
         "io.kaizen-solutions" %% "virgil-core" % "1.1.0"
       )
     )

--- a/src/main/scala/io/kaizensolutions/virgil/Paged.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/Paged.scala
@@ -1,6 +1,5 @@
 package io.kaizensolutions.virgil
 
 import io.kaizensolutions.virgil.configuration.PageState
-import kyo.Chunk
 
-final case class Paged[A](data: Chunk[A], pageState: Option[PageState])
+final case class Paged[A](data: Seq[A], pageState: Option[PageState])

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlPrimitiveDecoderKyoInstances.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlPrimitiveDecoderKyoInstances.scala
@@ -1,7 +1,7 @@
 package io.kaizensolutions.virgil.codecs
 
 import io.kaizensolutions.virgil.codecs.CqlPrimitiveDecoder.ListPrimitiveDecoder
-import kyo.{Chunk, Chunks}
+import kyo.Chunk
 
 import scala.jdk.CollectionConverters.*
 
@@ -11,6 +11,6 @@ trait CqlPrimitiveDecoderKyoInstances:
   ): CqlPrimitiveDecoder.WithDriver[Chunk[A], java.util.List[element.DriverType]] =
     ListPrimitiveDecoder[Chunk, A, element.DriverType](
       element,
-      (driverList, transformElement) => Chunks.initSeq(driverList.asScala.map(transformElement).toIndexedSeq)
+      (driverList, transformElement) => Chunk.from(driverList.asScala.map(transformElement).toIndexedSeq)
     )
 object CqlPrimitiveDecoderKyoInstances extends CqlPrimitiveDecoderKyoInstances

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlPrimitiveEncoderKyoInstances.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlPrimitiveEncoderKyoInstances.scala
@@ -1,7 +1,7 @@
 package io.kaizensolutions.virgil.codecs
 
 import io.kaizensolutions.virgil.codecs.CqlPrimitiveEncoder.*
-import kyo.{pure, Chunk}
+import kyo.Chunk
 
 import scala.jdk.CollectionConverters.*
 
@@ -11,7 +11,7 @@ trait CqlPrimitiveEncoderKyoInstances:
   ): ListPrimitiveEncoder[Chunk, ScalaElem, element.DriverType] =
     ListPrimitiveEncoder[Chunk, ScalaElem, element.DriverType](
       element,
-      (chunk, transform) => chunk.map(transform).pure.toSeq.asJava
+      (chunk, transform) => chunk.map(transform).asJava
     )
 
 object CqlPrimitiveEncoderKyoInstances extends CqlPrimitiveEncoderKyoInstances

--- a/src/test/scala/io/kaizensolutions/virgil/examples/Showcase.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/examples/Showcase.scala
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
  */
 object Showcase extends KyoApp:
   run:
-    val program: Unit < (Envs[CQLExecutor] & Fibers) =
+    val program: Unit < (Env[CQLExecutor] & Async) =
       val one   = 1
       val two   = 2
       val Alice = "Alice"
@@ -34,16 +34,15 @@ object Showcase extends KyoApp:
       for
         _        <- CQLExecutor.executeMutation(insertAlice)
         _        <- CQLExecutor.executeMutation(insertBob)
-        res      <- CQLExecutor.execute(query).runSeq
-        (data, _) = res
-        _        <- IOs(println(data))
+        data      <- CQLExecutor.execute(query).run
+        _        <- IO(println(data))
         page     <- CQLExecutor.executePage(query)
-        _        <- IOs(println(page.data))
+        _        <- IO(println(page.data))
       yield ()
 
     for
       executor <- CQLExecutor(CqlSession.builder().withKeyspace("virgil"))
-      result   <- Envs.run(executor)(program)
+      result   <- Env.run(executor)(program)
     yield result
 
 final case class ExampleRow(id: Int, info: String)


### PR DESCRIPTION
- Scala to 3.5.1 (I noticed 3.5.2 has a compilation time regression)
- Add compiler flags to prevent discarding Kyo computations
- Remove casting where possible
- Remove `Flat` where `Tag` is available

---
A few notes:

- We may want Java conversions for kyo-data: `Optional` or `ArrayList`, etc
- `Fiber.fromCompletionStage` should return a `Fiber` pending `IO`, not `Async`. Then we should add `Async.fromCompletionStage`...
- `Stream.apply` could also accept `Stream[A, S1] < S2` to avoid users from needing to write: `Stream(stream.map(_.emit)`